### PR TITLE
Explicitly specify to -std=c++11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author='Yukino Ikegami',
     author_email='yknikgm@gmail.com',
     url='http://github.com/ikegami-yukino/neologdn',
-    ext_modules=[Extension('neologdn', ['neologdn.cpp'], language='c++')],
+    ext_modules=[Extension('neologdn', ['neologdn.cpp'], language='c++', extra_compile_args=["-std=c++11"])],
     license='Apache Software License',
     keywords=['japanese', 'MeCab'],
     classifiers=(


### PR DESCRIPTION
In gcc (Ubuntu 4.8.4-2ubuntu1~14.04) 4.8.4, Ubuntu 14.04.3 LTS.

```
$ pip install neologdn
Collecting neologdn
  Downloading neologdn-0.1.1.tar.gz (42kB)
    100% |████████████████████████████████| 45kB 7.4MB/s
Installing collected packages: neologdn
  Running setup.py install for neologdn
    Complete output from command /opt/python/3.4/bin/python3.4 -c "import setuptools, tokenize;__file__='/tmp/pip-build-unwl0aey/neologdn/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-94fbl67y-record/install-record.txt --single-version-externally-managed --compile:
    running install
    running build
    running build_ext
    building 'neologdn' extension
    creating build
    creating build/temp.linux-i686-3.4
    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/opt/python/3.4/include/python3.4m -c neologdn.cpp -o build/temp.linux-i686-3.4/neologdn.o
    cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++ [enabled by default]
    In file included from /usr/include/c++/4.8/unordered_map:35:0,
                     from neologdn.cpp:255:
    /usr/include/c++/4.8/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
     #error This file requires compiler and library support for the \
      ^
    neologdn.cpp:663:8: error:‘unordered_ma’ in namespace‘st’ does not name a typetype
     static std::unordered_map<Py_UNICODE,Py_UNICODE>  __pyx_v_8neologdn_conversion_map;
            ^
    neologdn.cpp:664:8: error:‘unordered_ma’ in namespace‘st’ does not name a typetype
     static std::unordered_map<Py_UNICODE,Py_UNICODE>  __pyx_v_8neologdn_kana_ten_map;
            ^
    neologdn.cpp:665:8: error:‘unordered_ma’ in namespace‘st’ does not name a typetype
     static std::unordered_map<Py_UNICODE,Py_UNICODE>  __pyx_v_8neologdn_kana_maru_map;
            ^
    neologdn.cpp:666:8: error:‘unordered_se’ in namespace‘st’ does not name a typetype
     static std::unordered_set<Py_UNICODE>  __pyx_v_8neologdn_blocks;
            ^
    neologdn.cpp:667:8: error:‘unordered_se’ in namespace‘st’ does not name a typetype
     static std::unordered_set<Py_UNICODE>  __pyx_v_8neologdn_basic_latin;
            ^
    neologdn.cpp: In function‘PyObject* __pyx_f_8neologdn_normalize(PyObject*, int’:’:
    neologdn.cpp:1800:21: error:‘__pyx_v_8neologdn_block’ was not declared in this scopepe
           __pyx_t_10 = (__pyx_v_8neologdn_blocks.count(__pyx_v_prev) != 0);
                         ^       
    neologdn.cpp:1842:21: error:‘__pyx_v_8neologdn_basic_lati’ was not declared in this scopepe
           __pyx_t_10 = (__pyx_v_8neologdn_basic_latin.count(__pyx_v_prev) != 0);
                         ^       
    neologdn.cpp:2094:24: error:‘__pyx_v_8neologdn_kana_ten_ma’ was not declared in this scopepe
               __pyx_v_c = (__pyx_v_8neologdn_kana_ten_map[__pyx_v_prev]);
                            ^    
    neologdn.cpp:2132:24: error:‘__pyx_v_8neologdn_kana_maru_ma’ was not declared in this scopepe
               __pyx_v_c = (__pyx_v_8neologdn_kana_maru_map[__pyx_v_prev]);
                            ^    
    neologdn.cpp:2151:23: error:‘__pyx_v_8neologdn_conversion_ma’ was not declared in this scopepe
             __pyx_t_10 = (__pyx_v_8neologdn_conversion_map.count(__pyx_v_c) != 0);
                           ^     
    neologdn.cpp:2186:23: error:‘__pyx_v_8neologdn_block’ was not declared in this scopepe
             __pyx_t_11 = (__pyx_v_8neologdn_blocks.count(__pyx_v_c) != 0);
                           ^   
    neologdn.cpp: In function‘PyObject* PyInit_neologdn(’:’:
    neologdn.cpp:4267:6: erro‘__pyx_v_8neologdn_conversion_ma’ was not declared in this scopepepe
         (__pyx_v_8neologdn_conversion_map[__pyx_t_10]) = __pyx_t_9;
          ^                    
    neologdn.cpp:4398:6: erro‘__pyx_v_8neologdn_kana_ten_ma’ was not declared in this scopepepe
         (__pyx_v_8neologdn_kana_ten_map[__pyx_t_10]) = __pyx_t_9;
          ^                    
    neologdn.cpp:4529:6: erro‘__pyx_v_8neologdn_kana_maru_ma’ was not declared in this scopepepe
         (__pyx_v_8neologdn_kana_maru_map[__pyx_t_10]) = __pyx_t_9;
          ^                    
    neologdn.cpp:4773:5: error:‘__pyx_v_8neologdn_block’ was not declared in this scopepe
         __pyx_v_8neologdn_blocks.insert(__pyx_t_9);
         ^
    neologdn.cpp:4861:5: error:‘__pyx_v_8neologdn_basic_lati’ was not declared in this scopepe
         __pyx_v_8neologdn_basic_latin.insert(__pyx_t_9);
         ^
    error: command 'gcc' failed with exit status 1

    ----------------------------------------
Command "/opt/python/3.4/bin/python3.4 -c "import setuptools, tokenize;__file__='/tmp/pip-build-unwl0aey/neologdn/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-94fbl67y-record/install-record.txt --single-version-externally-m
anaged --compile" failed with error code 1 in /tmp/pip-build-unwl0aey/neologdn
```

This file requires compiler and library support for the C++11, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.

```
running install
running build
running build_ext
building 'neologdn' extension
gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/opt/python/3.4/include/python3.4m -c neologdn.cpp -o build/temp.linux-i686-3.4/neologdn.o -std=c++11
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++ [enabled by default]
creating build/lib.linux-i686-3.4
g++ -pthread -shared build/temp.linux-i686-3.4/neologdn.o -o build/lib.linux-i686-3.4/neologdn.cpython-34m.so
running install_lib
copying build/lib.linux-i686-3.4/neologdn.cpython-34m.so -> /opt/python/3.4/lib/python3.4/site-packages
running install_egg_info
Writing /opt/python/3.4/lib/python3.4/site-packages/neologdn-0.1.1-py3.4.egg-info
```
