### PR TITLE
Check if a previous character of daku-ten character is in maps.

### DIFF
--- a/neologdn.pyx
+++ b/neologdn.pyx
@@ -133,10 +133,10 @@ cpdef unicode normalize(unicode text, int repeat=0):
             elif c in TILDES:
                 continue
             else:
-                if c == 'ﾞ':
+                if c == 'ﾞ' and kana_ten_map.count(prev):
                     pos -= 1
                     c = kana_ten_map[prev]
-                elif c == 'ﾟ':
+                elif c == 'ﾟ' and kana_maru_map.count(prev):
                     pos -= 1
                     c = kana_maru_map[prev]
                 elif conversion_map.count(c):

--- a/test_neologdn.py
+++ b/test_neologdn.py
@@ -31,6 +31,7 @@ class TestNeologdn(unittest.TestCase):
         self.assertEqual(normalize(u'a˗֊‐‑‒–⁃⁻₋−'), "a-")
         self.assertEqual(normalize(u'あ﹣－ｰ—―─━ー'), u"あー")
         self.assertEqual(normalize(u'チルダ~∼∾〜〰～'), u"チルダ")
+        self.assertEqual(normalize(u'(ﾟ∀ﾟ )'), u"(゜∀゜)")
 
     def test_normalize_lengthened(self):
         self.assertEqual(normalize("うまああああああああああああい", repeat=7), "うまあああああああい")


### PR DESCRIPTION
When a previous character of daku-ten and han-daku-ten characters is invalid and is not in maps, the code insert a null character because unordered_map creates a new entry when it does not have a given key. I fixed it to check if a given character is in maps.
I did not update .cpp file. Is it required?