### PR TITLE
osx: Use libc++ explicitly instead of libstdc++

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ with open('neologdn.cpp', 'r', encoding='utf8') as f:
 
 extra_compile_args = ["-std=c++11"]
 if platform.system() == "Darwin":
+    extra_compile_args.append("-mmacosx-version-min=10.7")
     extra_compile_args.append("-stdlib=libc++")
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,15 @@
 from codecs import open
 import re
 from setuptools import setup, Extension
-
+import platform
 
 with open('neologdn.cpp', 'r', encoding='utf8') as f:
     version = re.compile(
         r".*__version__ = '(.*?)'", re.S).match(f.read()).group(1)
+
+extra_compile_args = ["-std=c++11"]
+if platform.system() == "Darwin":
+    extra_compile_args.append("-stdlib=libc++")
 
 setup(
     name='neologdn',
@@ -15,7 +19,7 @@ setup(
     author_email='yknikgm@gmail.com',
     url='http://github.com/ikegami-yukino/neologdn',
     ext_modules=[Extension('neologdn', ['neologdn.cpp'],
-                           language='c++', extra_compile_args=["-std=c++11"])],
+                           language='c++', extra_compile_args=extra_compile_args)],
     license='Apache Software License',
     keywords=['japanese', 'MeCab'],
     classifiers=(


### PR DESCRIPTION
This fixes a compile error with clang shipped with mac osx 10.13, which tries to use old libstdc++ by default. 

```
pip install neologdn
Collecting neologdn
  Using cached neologdn-0.2.1.tar.gz
Building wheels for collected packages: neologdn
  Running setup.py bdist_wheel for neologdn ... error
  Complete output from command /Users/xxx/anaconda3/bin/python -u -c "import setuptools, tokenize;__file__='/private/var/folders/m9/v0b20f9j7ll9hcht7ptq63sc0000gp/T/pip-build-10r0x9ir/neologdn/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /var/folders/m9/v0b20f9j7ll9hcht7ptq63sc0000gp/T/tmpp38qblnfpip-wheel- --python-tag cp36:
  running bdist_wheel
  running build
  running build_ext
  building 'neologdn' extension
  creating build
  creating build/temp.macosx-10.7-x86_64-3.6
  gcc -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/Users/xxx/anaconda3/include -arch x86_64 -I/Users/xxx/anaconda3/include -arch x86_64 -I/Users/xxx/anaconda3/include/python3.6m -c neologdn.cpp -o build/temp.macosx-10.7-x86_64-3.6/neologdn.o -std=c++11
  neologdn.cpp:255:10: fatal error: 'unordered_map' file not found
  #include <unordered_map>
           ^~~~~~~~~~~~~~~
  1 error generated.
  error: command 'gcc' failed with exit status 1
```

```
  gcc -v
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 9.0.0 (clang-900.0.39.2)
Target: x86_64-apple-darwin17.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

  find  /usr/include/c++/4.2.1 -type f -name "unordered_map"
/usr/include/c++/4.2.1/tr1/unordered_map
```

Ref: https://stackoverflow.com/questions/40301619/unordered-map-file-not-found-error-when-compiling-with-xcode-7-3-1